### PR TITLE
Fix fail on initialisation 

### DIFF
--- a/bluetoothScanner.py
+++ b/bluetoothScanner.py
@@ -15,8 +15,8 @@ import struct
 debug = 0
 
 """Either use 'RSSI' mode, or 'LOOKUP' mode.  RSSI is more reliable."""
-# mode = "RSSI"
-mode = "LOOKUP"
+mode = "RSSI"
+# mode = "LOOKUP"
 
 class BtSensor:
     """Represents a Bluetooth device"""

--- a/bluetoothScanner.py
+++ b/bluetoothScanner.py
@@ -15,8 +15,8 @@ import struct
 debug = 0
 
 """Either use 'RSSI' mode, or 'LOOKUP' mode.  RSSI is more reliable."""
-mode = "RSSI"
-# mode = "LOOKUP"
+# mode = "RSSI"
+mode = "LOOKUP"
 
 class BtSensor:
     """Represents a Bluetooth device"""
@@ -40,6 +40,7 @@ class BtSensor:
         self.far_count = 0
         self.near_count = 0
         self.rssi = None
+        self.state = "OFF"
 
         self.publish_state()
 


### PR DESCRIPTION
The state attribute in `bluetoothScanner.py` was being referenced before it was being declared, and thus failed immediately on start.  I declared it with a default value of `OFF`, and it fixed the problem for me.

I'm not sure how this worked before, but in my case I've only configured it to scan bluetooth and report on MQTT.